### PR TITLE
Update for standardized format of cRGB

### DIFF
--- a/src/Kaleidoscope-Hardware-Shortcut.cpp
+++ b/src/Kaleidoscope-Hardware-Shortcut.cpp
@@ -37,18 +37,18 @@ void Shortcut::setup(void) {
 }
 
 void Shortcut::setCrgbAt(uint8_t i, cRGB crgb) {
-    leds[i] = crgb;
+    leds[i] = asCGRB(crgb);
 }
 
 void Shortcut::setCrgbAt(byte row, byte col, cRGB color) {
 }
 
 cRGB Shortcut::getCrgbAt(uint8_t i) {
-    return leds[i];
+    return asCRGB(leds[i]);
 }
 
 void Shortcut::syncLeds() {
-    ws2812_sendarray((uint8_t *)leds,sizeof(cRGB) * LED_COUNT);
+    ws2812_sendarray((uint8_t *)leds,sizeof(cGRB) * LED_COUNT);
 }
 
 void Shortcut::readMatrix() {

--- a/src/Kaleidoscope-Hardware-Shortcut.h
+++ b/src/Kaleidoscope-Hardware-Shortcut.h
@@ -21,18 +21,11 @@
 #include <Arduino.h>
 #include <AtmegaScanner.h>
 
+#include "Kaleidoscope-Hardware.h"
 #define HARDWARE_IMPLEMENTATION Shortcut
 
 #define COLS 14
 #define ROWS 4
-
-typedef struct {
-  uint8_t g;
-  uint8_t r;
-  uint8_t b;
-} cRGB;
-
-#define CRGB(r, g, b) (cRGB){g, r, b}
 
 #define LED_COUNT 16
 
@@ -67,7 +60,7 @@ class Shortcut {
     AtmegaScanner<COLS, ROWS> scanner;
 
   private:
-    cRGB leds[LED_COUNT];
+    cGRB leds[LED_COUNT];
     static uint32_t leftHandMask;
     static uint32_t rightHandMask;
 };


### PR DESCRIPTION
This is pull request # 4/4 unifying the definition of `cRGB` across hardwares.  The other three pull requests are against `keyboardio/Kaleidoscope`, `keyboardio/Kaleidoscope-Hardware-Model01`, and `keyboardio/KeyboardioScanner`.  None of the four pull requests will build without the others, unfortunately.

The rationale for these pull requests is as follows.  First, a unified definition of `cRGB` is intuitive and elegant.  As part of the core hardware API, it also makes sense to define `cRGB` in the Kaleidoscope core.  

Second, this brings down a major barrier to implementing an actual abstract hardware base class (which is planned as a followup series of pull requests against these same repos; however, the issue of unifying `cRGB` seemed separate enough to warrant separate pull requests with their own discussion).  In fact, the unified definition of `cRGB` is declared by itself in a file called “Kaleidoscope-Hardware.h”, which is very forward-looking as eventually it will simply be declared as part of the abstract hardware base class.

Third, although it may seem at first glance that these pull requests may harm performance in terms of code size and/or execution time, this is actually not the case.  The additional function calls are inlined, and the resulting code generally just takes struct-copy operations that were already happening and changes them to copy struct members to different places.  The code is more verbose, but should compile down to the same number of operations to my knowledge.  To back up these assertions, we compare results of compiling a few sketches before and after these four pull requests are applied.  For the Model 01, we build the two sketches in `keyboardio/Kaleidoscope/examples`; the unified `cRGB` definition results in the exact same code size for `AppSwitcher`, and actually a 2-byte *improvement* for `Kaleidoscope`.  For the Shortcut, we build the sketch in `shortcutgg/Kaleidoscope-Hardware-Shortcut/examples`; again we end up with the exact same code size with or without these four pull requests.  I would imagine these results also indicate execution time hasn’t changed.